### PR TITLE
#7: Binary Value Payload Support

### DIFF
--- a/js/kafka-client.js
+++ b/js/kafka-client.js
@@ -30,7 +30,7 @@ module.exports = function(RED) {
             options.retry.retries =  parseInt(config.retries);
         }
 
-        if(config.auth == 'tls'){
+        if(config.auth === 'tls'){
             options.ssl = new Object();
             options.ssl.ca = [fs.readFileSync(config.tlscacert, 'utf-8')];
             options.ssl.cert = fs.readFileSync(config.tlsclientcert, 'utf-8');
@@ -39,7 +39,7 @@ module.exports = function(RED) {
             options.ssl.rejectUnauthorized = config.tlsselfsign;
         }
 
-        else if(config.auth == 'sasl'){
+        else if(config.auth === 'sasl'){
             options.ssl = config.saslssl;
 
             options.sasl = new Object();

--- a/js/kafka-consumer.html
+++ b/js/kafka-consumer.html
@@ -70,6 +70,10 @@
             <input type="checkbox" id="node-input-allowautotopiccreation">
         </div>
         <div class="form-row">
+            <label for="node-input-allowbinaryvaluepayload"><i class="fa fa-tag"></i> Allow Auto Topic Creation</label>
+            <input type="checkbox" id="node-input-allowbinaryvaluepayload">
+        </div>
+        <div class="form-row">
             <label for="node-input-clearoffsets"><i class="fa fa-eraser"></i> Clear Offsets</label>
             <input type="checkbox" id="node-input-clearoffsets">
         </div>
@@ -101,7 +105,8 @@
             maxwaittimeinms: {value: 5000, required:true},
             frombeginning: {value: false, required:true},
             clearoffsets: {value: false, required:true},
-            allowautotopiccreation: {value:false, required:true}
+            allowautotopiccreation: {value:false, required:true},
+            allowbinaryvaluepayload: {value: false, required:true}
         },
         inputs:0,
         outputs:1,

--- a/js/kafka-consumer.js
+++ b/js/kafka-consumer.js
@@ -81,7 +81,11 @@ module.exports = function(RED) {
                 payload.payload = message;
                 
                 payload.payload.key= message.key ? message.key.toString() : null;
-                payload.payload.value = message.value.toString();
+                if (message.value instanceof Buffer && config.advancedoptions && config.allowbinaryvaluepayload) {
+                    payload.payload.value = message.value;
+                } else {
+                    payload.payload.value = message.value.toString();
+                }
 
                 for(const [key, value] of Object.entries(payload.payload.headers)){
                     payload.payload.headers[key] = value.toString();


### PR DESCRIPTION
Added an option to handle binary value payload through Kafka. Can be enabled as an advanced option.