### PR TITLE
#17: Add self-signed certificate option for SASL SSL configuration

### DIFF
--- a/js/kafka-client.html
+++ b/js/kafka-client.html
@@ -91,6 +91,10 @@
 			<input type="checkbox" id="node-config-input-saslssl" style="display: inline-block; width: auto; vertical-align: top;">
 			<label for="node-config-input-saslssl" style="width: auto">Use SSL</label>
 		</div>
+		<div class="form-row">
+			<input type="checkbox" id="node-config-input-saslselfsign" style="display: inline-block; width: auto; vertical-align: top;">
+			<label for="node-config-input-saslselfsign" style="width: auto">Self Signed Cert</label>
+		</div>
 	</div>
 	<div class="form-row">
         <label for="node-config-input-advancedretry" style="display: inline-block; width: auto; vertical-align: top;"><i class="fa fa-clock-o"></i> Advanced Retry Options</label>
@@ -148,6 +152,7 @@
 
 			saslssl: { value: true, required: false },
 			saslmechanism: { value: 'plain', required: false },
+			saslselfsign: { value: false, required: false },
 
 			loglevel: { value: "error", required: true },
 		},

--- a/js/kafka-client.html
+++ b/js/kafka-client.html
@@ -93,7 +93,7 @@
 		</div>
 		<div class="form-row">
 			<input type="checkbox" id="node-config-input-saslselfsign" style="display: inline-block; width: auto; vertical-align: top;">
-			<label for="node-config-input-saslselfsign" style="width: auto">Self Signed Cert</label>
+			<label for="node-config-input-saslselfsign" style="width: auto">Allow self-signed certificate</label>
 		</div>
 	</div>
 	<div class="form-row">

--- a/js/kafka-client.js
+++ b/js/kafka-client.js
@@ -40,15 +40,12 @@ module.exports = function(RED) {
         }
 
         else if(config.auth == 'sasl'){
-            options.ssl = config.saslssl ? {} : false;
+            options.ssl = config.saslssl ? { rejectUnauthorized: !config.saslselfsign } : false;
 
             options.sasl = new Object();
             options.sasl.mechanism = config.saslmechanism || 'plain';
             options.sasl.username = node.credentials.saslusername;
             options.sasl.password = node.credentials.saslpassword;
-            if(config.saslssl){
-                options.ssl.rejectUnauthorized = !config.saslselfsign;
-            }
         }
     
         node.options = options;

--- a/js/kafka-client.js
+++ b/js/kafka-client.js
@@ -40,12 +40,15 @@ module.exports = function(RED) {
         }
 
         else if(config.auth == 'sasl'){
-            options.ssl = config.saslssl;
+            options.ssl = config.saslssl ? {} : false;
 
             options.sasl = new Object();
             options.sasl.mechanism = config.saslmechanism || 'plain';
             options.sasl.username = node.credentials.saslusername;
             options.sasl.password = node.credentials.saslpassword;
+            if(config.saslssl){
+                options.ssl.rejectUnauthorized = !config.saslselfsign;
+            }
         }
     
         node.options = options;


### PR DESCRIPTION
Introduced an option to use self-signed certificates in the SASL_SSL configuration, enhancing flexibility in secure connections.